### PR TITLE
Allow configuration of JavaScript tabstop

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -20,7 +20,8 @@ chrome.extension.onRequest.addListener(function(request, sender, sendResponse) {
         lang: window.tab_langs[sender.tab.id],
         font: localStorage.font || 'Inconsolata',
         theme: localStorage.theme || 'sunburst',
-        line_numbers: localStorage.line_numbers || true
+        line_numbers: localStorage.line_numbers || true,
+        javascript_tabstop: localStorage.javascript_tabstop || '4'
     });
 
     !!request.inject && loadJs(request.inject, function(xhr) {

--- a/js/content_script.js
+++ b/js/content_script.js
@@ -161,7 +161,7 @@ if (!isNormalPage || isSighted) chrome.extension.sendRequest({preferences: true}
             }
             code.innerHTML = original.innerHTML;
             if(lang == 'javascript')
-                code.textContent = js_beautify(code.textContent, {preserve_newlines: true});
+                code.textContent = js_beautify(code.textContent, {preserve_newlines: true, indent_size: prefs.javascript_tabstop});
             code.innerHTML = '<code>' + code.innerHTML + '</code>';
             code.classList.add(lang);
             hljs.highlightBlock(code.firstChild, '    ', false);

--- a/js/options.js
+++ b/js/options.js
@@ -12,6 +12,11 @@ document.addEventListener("DOMContentLoaded", function() {
         localStorage.font = font;
     });
 
+    document.getElementById('javascript_tabstop').addEventListener('change', function(e){
+        var javascriptTabstop = e.target.options[e.target.selectedIndex].value;
+        localStorage.javascript_tabstop = javascriptTabstop;
+    });
+
     document.getElementById('show-line-numbers').addEventListener('change', function(e){
         var line_numbers = e.target.checked;
         document.getElementById('line-numbers').style.display = line_numbers ? 'block' : 'none';
@@ -21,6 +26,7 @@ document.addEventListener("DOMContentLoaded", function() {
     localStorage.theme = localStorage.theme || 'sunburst';
     localStorage.font = localStorage.font || 'Inconsolata';
     localStorage.line_numbers = localStorage.line_numbers || true;
+    localStorage.javascript_tabstop = localStorage.javascript_tabstop || '4';
 
     loadCSS('css/' + localStorage.theme + '.css');
     document.querySelector('#theme option[value="' + localStorage.theme + '"]').selected = true;
@@ -30,6 +36,7 @@ document.addEventListener("DOMContentLoaded", function() {
     document.querySelector('#line-numbers').style.display = eval(localStorage.line_numbers) ? 'block' : 'none';
     document.querySelector('#show-line-numbers').checked = eval(localStorage.line_numbers);
     document.querySelector('code').style.fontFamily = localStorage.font;
+    document.querySelector('#javascript_tabstop option[value="' + localStorage.javascript_tabstop + '"]').selected = true;
     hljs.initHighlighting();
 });
 

--- a/options.html
+++ b/options.html
@@ -39,6 +39,12 @@
         <option value="ProggyClean">Proggy Clean</option>
         <option value="Consolas">Consolas</option>
       </select>
+      <h3>Select your JavaScript indentation size</h3>
+      <select name="javascript_tabstop" id="javascript_tabstop">
+        <option value="2">2 spaces per level of indentation</option>
+        <option value="4">4 spaces per level of indentation</option>
+        <option value="8">8 spaces per level of indentation</option>
+      </select>
       <h3>Show line numbers? <input type="checkbox" id="show-line-numbers" /></h3>
       <div class="clear"></div>
       <ul id="line-numbers"><li>01</li><li>02</li><li>03</li><li>04</li><li>05</li><li>06</li><li>07</li><li>08</li><li>09</li><li>10</li><li>11</li><li>12</li><li>13</li><li>14</li><li>15</li><li>16</li><li>17</li><li>18</li><li>19</li><li>20</li><li>21</li><li>22</li><li>23</li><li>24</li></ul>


### PR DESCRIPTION
The plugin is awesome!  I noticed that JS highlighting always has a tabstop of 4, as a default option from the `js_beautify()` function included in `highlight.js`.  I added a configuration option, similar to the others, in `options.html` for "Select your JavaScript indentation size"
