### PR TITLE
Fixes interaction with Sight and several other extensions

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -2,70 +2,70 @@
   font-family: 'Inconsolata';
   font-style: normal;
   font-weight: normal;
-  src: url('chrome-extension://epmaefhielclhlnmjofcdapbeepkmggh/css/Inconsolata.ttf');
+  src: url('Inconsolata.ttf');
 }
 
 @font-face {
   font-family: 'Courier New';
   font-style: normal;
   font-weight: normal;
-  src: url('chrome-extension://epmaefhielclhlnmjofcdapbeepkmggh/css/CourierNew.ttf');
+  src: url('CourierNew.ttf');
 }
 
 @font-face {
   font-family: 'Monaco';
   font-style: normal;
   font-weight: normal;
-  src: url('chrome-extension://epmaefhielclhlnmjofcdapbeepkmggh/css/Monaco.ttf');
+  src: url('Monaco.ttf');
 }
 
 @font-face {
   font-family: 'Anonymous Pro';
   font-style: normal;
   font-weight: normal;
-  src: url('chrome-extension://epmaefhielclhlnmjofcdapbeepkmggh/css/AnonymousPro.ttf');
+  src: url('AnonymousPro.ttf');
 }
 
 @font-face {
   font-family: 'DejaVuSansMono';
   font-style: normal;
   font-weight: normal;
-  src: url('chrome-extension://epmaefhielclhlnmjofcdapbeepkmggh/css/DejaVuSansMono.ttf');
+  src: url('DejaVuSansMono.ttf');
 }
 
 @font-face {
   font-family: 'DroidSansMono';
   font-style: normal;
   font-weight: normal;
-  src: url('chrome-extension://epmaefhielclhlnmjofcdapbeepkmggh/css/DroidSansMono.ttf');
+  src: url('DroidSansMono.ttf');
 }
 
 @font-face {
   font-family: 'Monofur';
   font-style: normal;
   font-weight: normal;
-  src: url('chrome-extension://epmaefhielclhlnmjofcdapbeepkmggh/css/Monofur.ttf');
+  src: url('Monofur.ttf');
 }
 
 @font-face {
   font-family: 'ProFont';
   font-style: normal;
   font-weight: normal;
-  src: url('chrome-extension://epmaefhielclhlnmjofcdapbeepkmggh/css/ProFont.ttf');
+  src: url('ProFont.ttf');
 }
 
 @font-face {
   font-family: 'ProggyClean';
   font-style: normal;
   font-weight: normal;
-  src: url('chrome-extension://epmaefhielclhlnmjofcdapbeepkmggh/css/ProggyClean.ttf');
+  src: url('ProggyClean.ttf');
 }
 
 @font-face {
   font-family: 'Consolas';
   font-style: normal;
   font-weight: normal;
-  src: url('chrome-extension://epmaefhielclhlnmjofcdapbeepkmggh/css/Consolas.ttf');
+  src: url('Consolas.ttf');
 }
 
 body {

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Sight",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "description": "The Syntax Highlighter for Chrome",
   "minimum_chrome_version": "8",
   "background_page": "background.html",
@@ -15,5 +15,11 @@
     "16": "images/icon16.png",
     "48": "images/icon48.png",
     "128": "images/icon128.png"
-  }
+  },
+  "content_scripts": [ {
+    "all_frames": true,
+    "js": ["js/content_script.js"],
+    "matches": ["http://*/*", "https://*/*", "ftp://*/*", "file:///*"],
+    "run_at": "document_end"
+  } ]
 }


### PR DESCRIPTION
Tested and working with Adblock, Google Translate, and Evernote Web Clipper all installed and enabled.  Also fixes CSS font pathing to relative instead of absolute for easier development mode testing.

This should address most issues with conflicts with other extensions.
