### PR TITLE
Fix Content-Type detection if parameters are present

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -71,7 +71,7 @@
     var contentType = getHeaderByName(headers, 'content-type');
 
     if (contentType) {
-      return contentType.split('/').pop().split(';').shift().trim();
+      return contentType.split(';').shift().split('/').pop().trim();
     } else {
       return null;
     }


### PR DESCRIPTION
According to Media Type defininition in RFC 2616 [1](http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7), type/subtype
can be followed by any kind of parameters. The usage of a slash
character in a parameter is not forbidden.

This change uses ";" as delimiter as described and ignores correctly
any present parameters. The following Content-Type will now be
successfully detected:

```
application/json
application/json; charset=utf-8
application/json; schema="prometheus/telemetry"; version=0.0.2
```
