### PR TITLE
add support for groovy

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -15,7 +15,7 @@
     go:          ['go'],
     haskell:     ['hs'],
     http:        ['http'],
-    java:        ['java', 'class', 'fx'],
+    java:        ['java', 'class', 'fx', 'groovy', 'gsh', 'gvy', 'gy'],
     javascript:  ['js'],
     json:        ['json'],
     lisp:        ['lsp', 'lisp', 'cl', 'el', 'scm', 'clj'],


### PR DESCRIPTION
add support for groovy

groovy is an abject-oriented language alternative for Java platform.  for code highlighting sake, the language is similar so I just added the groovy file extensions to the java list.  screenshot of test included.

![image](https://f.cloud.github.com/assets/166513/2387380/463e1506-a936-11e3-9f32-ac54aaa5cfde.png)
