### PR TITLE
add support for local files

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -136,7 +136,7 @@
   chrome.webRequest.onCompleted.addListener(function(details) {
     var language, contentType = getContentTypeFromHeaders(details.responseHeaders);
 
-    if (contentType !== null && contentType !== 'html') {
+    if (contentType !== 'html') {
       if (language = detectLanguage(contentType, details.url)) {
         chrome.tabs.insertCSS(details.tabId, { file: 'css/reset.css' });
         chrome.tabs.insertCSS(details.tabId, { file: 'css/main.css' });


### PR DESCRIPTION
add support for local files #45

removing the check for null content-type allows highlighting on local files.  a quick test shows this works for local files and retains functionality for hosted files.  before this gets merged I would like to know why the check was in there, maybe there is some history I am missing.

![image](https://f.cloud.github.com/assets/166513/2387576/67fdac72-a938-11e3-9835-7bd02bb806e1.png)
