### PR TITLE
add option for font-size

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -39,10 +39,11 @@
   const OPTIONS_DEFAULTS = {
     theme: 'sunburst',
     font: 'Inconsolata',
+    fontSize: 'medium',
     lineNumbers: false
   };
 
-  ['theme', 'font', 'lineNumbers'].forEach(function(option) {
+  ['theme', 'font', 'fontSize', 'lineNumbers'].forEach(function(option) {
     if (localStorage.getItem(option) === null) {
       localStorage.setItem(option, OPTIONS_DEFAULTS[option]);
     }
@@ -105,8 +106,9 @@
                  EXT_LANG_MAP[filename];
   }
 
-  function getHighlightingCode(font, language, showLineNumbers) {
+  function getHighlightingCode(font, fontSize, language, showLineNumbers) {
     var code = 'document.body.style.fontFamily = "' + font + '";';
+    code += 'document.body.style.fontSize = "' + fontSize + '";';
     code += 'var container = document.querySelector("pre");';
     code += 'container.classList.add("' + language + '");';
     code += 'hljs.highlightBlock(container, "  ", false, ' + showLineNumbers + ');';
@@ -123,6 +125,7 @@
       sendResponse({
         theme: localStorage.getItem('theme'),
         font: localStorage.getItem('font'),
+        fontSize: localStorage.getItem('fontSize'),
         lineNumbers: localStorage.getItem('lineNumbers')
       });
     } else {
@@ -147,13 +150,13 @@
               chrome.tabs.executeScript(details.tabId, { file: 'js/lib/beautify.js' }, function() {
                 chrome.tabs.executeScript(details.tabId, { code: JS_BEUTIFY_CODE }, function() {
                   chrome.tabs.executeScript(details.tabId, {
-                    code: getHighlightingCode(localStorage.getItem('font'), language, localStorage.getItem('lineNumbers'))
+                    code: getHighlightingCode(localStorage.getItem('font'), localStorage.getItem('fontSize'), language, localStorage.getItem('lineNumbers'))
                   });
                 });
               });
             } else {
               chrome.tabs.executeScript(details.tabId, {
-                code: getHighlightingCode(localStorage.getItem('font'), language, localStorage.getItem('lineNumbers'))
+                code: getHighlightingCode(localStorage.getItem('font'), localStorage.getItem('fontSize'), language, localStorage.getItem('lineNumbers'))
               });
             }
           });

--- a/js/options.js
+++ b/js/options.js
@@ -2,6 +2,7 @@
   doc.addEventListener('DOMContentLoaded', function() {
     var themeEl = doc.getElementById('theme');
     var fontEl  = doc.getElementById('font');
+    var fontSizeEl = doc.getElementById('font-size');
     var lineNumbersEl  = doc.getElementById('lineNumbers');
     var styleEl = doc.querySelector('link:last-of-type');
     var codeEl = doc.getElementById('code');
@@ -22,6 +23,10 @@
     function applyFont(font) {
       codeEl.style.fontFamily = font;
     }
+    
+    function applyFontSize(fontSize) {
+      codeEl.style.fontSize = fontSize;
+    }
 
     function applyLineNumbers(enabled) {
       codeEl.innerHTML = code;
@@ -37,6 +42,11 @@
       var font = fontEl.options[fontEl.selectedIndex].value;
       setOptions({ font: font }, applyFont.bind(null, font));
     });
+    
+    fontSizeEl.addEventListener('change', function() {
+      var fontSize = fontSizeEl.options[fontSizeEl.selectedIndex].value;
+      setOptions({ fontSize: fontSize }, applyFontSize.bind(null, fontSize));
+    });
 
     lineNumbersEl.addEventListener('change', function() {
       var enabled = lineNumbersEl.checked;
@@ -47,9 +57,11 @@
       var lineNumbers = JSON.parse(options.lineNumbers);
       themeEl.value = options.theme;
       fontEl.value = options.font;
+      fontSizeEl.value = options.fontSize;
       lineNumbersEl.checked = lineNumbers;
       applyTheme(options.theme);
       applyFont(options.font);
+      applyFontSize(options.fontSize);
       applyLineNumbers(lineNumbers);
     });
   });

--- a/options.html
+++ b/options.html
@@ -47,6 +47,16 @@
         <option value="ProggyClean">Proggy Clean</option>
         <option value="Consolas">Consolas</option>
       </select>
+      <h3>Select your font size</h3>
+      <select id="font-size">
+        <option value="xx-small">xx-small</option>
+        <option value="x-small">x-small</option>
+        <option value="small">small</option>
+        <option value="medium">medium</option>
+        <option value="large">large</option>
+        <option value="x-large">x-large</option>
+        <option value="xx-large">xx-large</option>
+      </select>
       <h3>Line numbers:<input id="lineNumbers" type="checkbox"></h3>
       <pre id="code" class="ruby">
 class Dog &lt; Animal


### PR DESCRIPTION
add option for font-size

allows user to choose from the available options: xx-small, x-small, small, medium, large, x-large, xx-large.  defaults to medium which matches the current fault.  screenshot attached. as requested in #32.

![image](https://f.cloud.github.com/assets/166513/2387833/a486f2e0-a93b-11e3-847e-35a4a9854735.png)
![image](https://f.cloud.github.com/assets/166513/2387852/c6d7621c-a93b-11e3-8246-495dc32840c3.png)
