### PR TITLE
Detect local (file:///) HTML and XML files

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -141,7 +141,7 @@
     var contentType = getContentTypeFromHeaders(details.responseHeaders);
     if (
       ['html', 'xml'].indexOf(contentType) != -1 ||
-      (details.url.indexOf('file:///') != -1 && ['html', 'xml'].indexOf(getExtensionFromFilename(getFilenameFromUrl(details.url))) == 0)
+      (details.url.indexOf('file:///') == 0 && ['html', 'xml'].indexOf(getExtensionFromFilename(getFilenameFromUrl(details.url))) == 0)
     ) {
       return;
     }


### PR DESCRIPTION
Chrome doesn't include a content-type for local HTML and XML files, this adds support for them to be rendered as pages instead of code.

It's a bit hard to follow, but it's more efficient this way since the second part will only be run if it's a `file:///` URL.

I tried to keep the code formatting consistent so this can be merged directly.
