### PR TITLE
Make body have colour scheme's background colour

### DIFF
--- a/css/arta.css
+++ b/css/arta.css
@@ -3,6 +3,11 @@ Date: 17.V.2011
 Author: pumbur <pumbur@pumbur.net>
 */
 
+body
+{
+  background: #222;
+}
+
 .hljs
 {
   display: block; padding: 0.5em;

--- a/css/ascetic.css
+++ b/css/ascetic.css
@@ -4,6 +4,10 @@ Original style from softwaremaniacs.org (c) Ivan Sagalaev <Maniac@SoftwareManiac
 
 */
 
+body {
+  background: white;
+}
+
 .hljs {
   display: block; padding: 0.5em;
   background: white; color: black;

--- a/css/atelier-dune.dark.css
+++ b/css/atelier-dune.dark.css
@@ -3,6 +3,10 @@
 /* Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16) */
 /* https://github.com/jmblog/color-themes-for-highlightjs */
 
+body {
+  background: #292824;
+}
+
 /* Atelier Dune Dark Comment */
 .hljs-comment,
 .hljs-title {

--- a/css/atelier-dune.light.css
+++ b/css/atelier-dune.light.css
@@ -3,6 +3,10 @@
 /* Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16) */
 /* https://github.com/jmblog/color-themes-for-highlightjs */
 
+body {
+  background: #fefbec;
+}
+
 /* Atelier Dune Light Comment */
 .hljs-comment,
 .hljs-title {

--- a/css/atelier-forest.dark.css
+++ b/css/atelier-forest.dark.css
@@ -3,6 +3,10 @@
 /* Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16) */
 /* https://github.com/jmblog/color-themes-for-highlightjs */
 
+body {
+  background: #2c2421;
+}
+
 /* Atelier Forest Dark Comment */
 .hljs-comment,
 .hljs-title {

--- a/css/atelier-forest.light.css
+++ b/css/atelier-forest.light.css
@@ -3,6 +3,10 @@
 /* Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16) */
 /* https://github.com/jmblog/color-themes-for-highlightjs */
 
+body {
+  background: #f1efee;
+}
+
 /* Atelier Forest Light Comment */
 .hljs-comment,
 .hljs-title {

--- a/css/atelier-heath.dark.css
+++ b/css/atelier-heath.dark.css
@@ -3,6 +3,10 @@
 /* Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16) */
 /* https://github.com/jmblog/color-themes-for-highlightjs */
 
+body {
+  background: #292329;
+}
+
 /* Atelier Heath Dark Comment */
 .hljs-comment,
 .hljs-title {

--- a/css/atelier-heath.light.css
+++ b/css/atelier-heath.light.css
@@ -3,6 +3,10 @@
 /* Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16) */
 /* https://github.com/jmblog/color-themes-for-highlightjs */
 
+body {
+  background: #f7f3f7;
+}
+
 /* Atelier Heath Light Comment */
 .hljs-comment,
 .hljs-title {

--- a/css/atelier-lakeside.dark.css
+++ b/css/atelier-lakeside.dark.css
@@ -3,6 +3,10 @@
 /* Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16) */
 /* https://github.com/jmblog/color-themes-for-highlightjs */
 
+body {
+  background: #1f292e;
+}
+
 /* Atelier Lakeside Dark Comment */
 .hljs-comment,
 .hljs-title {

--- a/css/atelier-lakeside.light.css
+++ b/css/atelier-lakeside.light.css
@@ -3,6 +3,10 @@
 /* Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16) */
 /* https://github.com/jmblog/color-themes-for-highlightjs */
 
+body {
+  background: #ebf8ff;
+}
+
 /* Atelier Lakeside Light Comment */
 .hljs-comment,
 .hljs-title {

--- a/css/atelier-seaside.dark.css
+++ b/css/atelier-seaside.dark.css
@@ -3,6 +3,10 @@
 /* Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16) */
 /* https://github.com/jmblog/color-themes-for-highlightjs */
 
+body {
+  background: #242924;
+}
+
 /* Atelier Seaside Dark Comment */
 .hljs-comment,
 .hljs-title {

--- a/css/atelier-seaside.light.css
+++ b/css/atelier-seaside.light.css
@@ -3,6 +3,10 @@
 /* Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16) */
 /* https://github.com/jmblog/color-themes-for-highlightjs */
 
+body {
+  background: #f0fff0;
+}
+
 /* Atelier Seaside Light Comment */
 .hljs-comment,
 .hljs-title {

--- a/css/dark.css
+++ b/css/dark.css
@@ -103,3 +103,7 @@ Dark style from softwaremaniacs.org (c) Ivan Sagalaev <Maniac@SoftwareManiacs.Or
 .xml .hljs-cdata {
   opacity: 0.5;
 }
+
+body {
+  background: #444;
+}

--- a/css/default.css
+++ b/css/default.css
@@ -4,6 +4,10 @@ Original style from softwaremaniacs.org (c) Ivan Sagalaev <Maniac@SoftwareManiac
 
 */
 
+body {
+  background: #f0f0f0;
+}
+
 .hljs {
   display: block; padding: 0.5em;
   background: #F0F0F0;

--- a/css/docco.css
+++ b/css/docco.css
@@ -2,6 +2,10 @@
 Docco style used in http://jashkenas.github.com/docco/ converted by Simon Madine (@thingsinjars)
 */
 
+body {
+  background: #f8f8ff;
+}
+
 .hljs {
   display: block; padding: 0.5em;
   color: #000;

--- a/css/far.css
+++ b/css/far.css
@@ -4,6 +4,10 @@ FAR Style (c) MajestiC <majestic2k@gmail.com>
 
 */
 
+body {
+  background: #000080;
+}
+
 .hljs {
   display: block; padding: 0.5em;
   background: #000080;

--- a/css/foundation.css
+++ b/css/foundation.css
@@ -6,6 +6,10 @@ Version: 1.0
 Date: 2013-04-02
 */
 
+body {
+  background: #eee;
+}
+
 .hljs {
   display: block; padding: 0.5em;
   background: #eee;

--- a/css/github.css
+++ b/css/github.css
@@ -4,6 +4,10 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
 */
 
+body {
+  background: #f8f8f8;
+}
+
 .hljs {
   display: block; padding: 0.5em;
   color: #333;

--- a/css/googlecode.css
+++ b/css/googlecode.css
@@ -4,6 +4,10 @@ Google Code style (c) Aahan Krish <geekpanth3r@gmail.com>
 
 */
 
+body {
+  background: white;
+}
+
 .hljs {
   display: block; padding: 0.5em;
   background: white; color: black;

--- a/css/idea.css
+++ b/css/idea.css
@@ -4,6 +4,10 @@ Intellij Idea-like styling (c) Vasily Polovnyov <vast@whiteants.net>
 
 */
 
+body {
+  background: #fff;
+}
+
 .hljs {
   display: block; padding: 0.5em;
   color: #000;

--- a/css/ir_black.css
+++ b/css/ir_black.css
@@ -2,6 +2,10 @@
   IR_Black style (c) Vasily Mikhailitchenko <vaskas@programica.ru>
 */
 
+body {
+  background: #000;
+}
+
 .hljs {
   display: block; padding: 0.5em;
   background: #000; color: #f8f8f8;

--- a/css/magula.css
+++ b/css/magula.css
@@ -121,3 +121,6 @@ Music: Aphex Twin / Xtal
   color: blue;
 }
 
+body {
+  background: #f4f4f4;
+}

--- a/css/mono-blue.css
+++ b/css/mono-blue.css
@@ -1,6 +1,10 @@
 /*
   Five-color theme from a single blue hue.
 */
+body {
+  background: #eaeef3;
+}
+
 .hljs {
   display: block; padding: 0.5em;
   background: #EAEEF3; color: #00193A;

--- a/css/monokai.css
+++ b/css/monokai.css
@@ -2,6 +2,10 @@
 Monokai style - ported by Luigi Maselli - http://grigio.org
 */
 
+body {
+  background: #272822;
+}
+
 .hljs {
   display: block; padding: 0.5em;
   background: #272822;

--- a/css/monokai_sublime.css
+++ b/css/monokai_sublime.css
@@ -4,6 +4,10 @@ Monokai Sublime style. Derived from Monokai by noformnocontent http://nn.mit-lic
 
 */
 
+body {
+  background: #23241f;
+}
+
 .hljs {
   display: block;
   padding: 0.5em;

--- a/css/obsidian.css
+++ b/css/obsidian.css
@@ -3,6 +3,10 @@
  * ported by Alexander Marenin (http://github.com/ioncreature)
  */
 
+body {
+    background: #282b2e;
+}
+
 .hljs {
     display: block; padding: 0.5em;
     background: #282B2E;

--- a/css/paraiso.dark.css
+++ b/css/paraiso.dark.css
@@ -4,6 +4,10 @@
     Inspired by the art of Rubens LP (http://www.rubenslp.com.br)
 */
 
+body {
+  background: #2f1e2e;
+}
+
 /* Paraíso Comment */
 .hljs-comment,
 .hljs-title {

--- a/css/paraiso.light.css
+++ b/css/paraiso.light.css
@@ -4,6 +4,10 @@
     Inspired by the art of Rubens LP (http://www.rubenslp.com.br)
 */
 
+body {
+  background: #e7e9db;
+}
+
 /* Paraíso Comment */
 .hljs-comment,
 .hljs-title {

--- a/css/railscasts.css
+++ b/css/railscasts.css
@@ -4,6 +4,10 @@ Railscasts-like style (c) Visoft, Inc. (Damien White)
 
 */
 
+body {
+  background: #232323;
+}
+
 .hljs {
   display: block;
   padding: 0.5em;

--- a/css/rainbow.css
+++ b/css/rainbow.css
@@ -4,6 +4,10 @@ Style with support for rainbow parens
 
 */
 
+body {
+  background: #474949;
+}
+
 .hljs {
   display: block; padding: 0.5em;
   background: #474949; color: #D1D9E1;

--- a/css/solarized_dark.css
+++ b/css/solarized_dark.css
@@ -4,6 +4,10 @@ Orginal Style from ethanschoonover.com/solarized (c) Jeremy Hull <sourdrums@gmai
 
 */
 
+body {
+  background: #002b36;
+}
+
 .hljs {
   display: block;
   padding: 0.5em;

--- a/css/solarized_light.css
+++ b/css/solarized_light.css
@@ -4,6 +4,10 @@ Orginal Style from ethanschoonover.com/solarized (c) Jeremy Hull <sourdrums@gmai
 
 */
 
+body {
+  background: #fdf6e3;
+}
+
 .hljs {
   display: block;
   padding: 0.5em;

--- a/css/sunburst.css
+++ b/css/sunburst.css
@@ -4,6 +4,10 @@ Sunburst-like style (c) Vasily Polovnyov <vast@whiteants.net>
 
 */
 
+body {
+  background: #000;
+}
+
 .hljs {
   display: block; padding: 0.5em;
   background: #000; color: #f8f8f8;

--- a/css/tomorrow-night-blue.css
+++ b/css/tomorrow-night-blue.css
@@ -3,6 +3,10 @@
 /* Original theme - https://github.com/chriskempson/tomorrow-theme */
 /* http://jmblog.github.com/color-themes-for-google-code-highlightjs */
 
+body {
+  background: #002451;
+}
+
 /* Tomorrow Comment */
 .hljs-comment,
 .hljs-title {

--- a/css/tomorrow-night-bright.css
+++ b/css/tomorrow-night-bright.css
@@ -2,6 +2,10 @@
 /* Original theme - https://github.com/chriskempson/tomorrow-theme */
 /* http://jmblog.github.com/color-themes-for-google-code-highlightjs */
 
+body {
+  background: black;
+}
+
 /* Tomorrow Comment */
 .hljs-comment,
 .hljs-title {

--- a/css/tomorrow-night-eighties.css
+++ b/css/tomorrow-night-eighties.css
@@ -2,6 +2,10 @@
 /* Original theme - https://github.com/chriskempson/tomorrow-theme */
 /* http://jmblog.github.com/color-themes-for-google-code-highlightjs */
 
+body {
+  background: #2d2d2d;
+}
+
 /* Tomorrow Comment */
 .hljs-comment,
 .hljs-title {

--- a/css/tomorrow-night.css
+++ b/css/tomorrow-night.css
@@ -3,6 +3,10 @@
 /* Original theme - https://github.com/chriskempson/tomorrow-theme */
 /* http://jmblog.github.com/color-themes-for-google-code-highlightjs */
 
+body {
+  background: #1d1f21;
+}
+
 /* Tomorrow Comment */
 .hljs-comment,
 .hljs-title {

--- a/css/tomorrow.css
+++ b/css/tomorrow.css
@@ -1,5 +1,9 @@
 /* http://jmblog.github.com/color-themes-for-google-code-highlightjs */
 
+body {
+  background: white;
+}
+
 /* Tomorrow Comment */
 .hljs-comment,
 .hljs-title {

--- a/css/vs.css
+++ b/css/vs.css
@@ -3,6 +3,10 @@
 Visual Studio-like style based on original C# coloring by Jason Diamond <jason@diamond.name>
 
 */
+body {
+  background: white;
+}
+
 .hljs {
   display: block; padding: 0.5em;
   background: white; color: black;

--- a/css/xcode.css
+++ b/css/xcode.css
@@ -4,6 +4,10 @@ XCode style (c) Angel Garcia <angelgarcia.mail@gmail.com>
 
 */
 
+body {
+  background: #fff;
+}
+
 .hljs {
   display: block; padding: 0.5em;
   background: #fff; color: black;

--- a/css/zenburn.css
+++ b/css/zenburn.css
@@ -5,6 +5,10 @@ based on dark.css by Ivan Sagalaev
 
 */
 
+body {
+  background: #3f3f3f;
+}
+
 .hljs {
   display: block; padding: 0.5em;
   background: #3F3F3F;


### PR DESCRIPTION
Make the body have the main background colour of the appropriate colour scheme. This makes a page with a short bit of code (like a one-line patch for instance) look a lot nicer, especially when using a dark theme, as it reduces the contrast between the page and the code.

**Before:**
![](http://i.imgur.com/XjuxKHw.png)

**After:**
![](http://i.imgur.com/qs9iK99.png)
