### PR TITLE
Workaround local html/xml viewing (issue #57)

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -112,8 +112,10 @@
     var code = 'document.body.style.fontFamily = "' + font + '";';
     code += 'document.body.style.fontSize = "' + fontSize + '";';
     code += 'var container = document.querySelector("pre");';
+    code += 'if (container) {';
     code += 'container.classList.add("' + language + '");';
     code += 'hljs.highlightBlock(container);';
+    code += '}';
     return code;
   }
 
@@ -144,6 +146,10 @@
     }
 
     var language = detectLanguage(contentType, details.url);
+    if ((['html', 'xml'].indexOf(language) != -1) && (contentType === null)) {
+      return;
+    }
+
     if (!language) {
       return;
     }


### PR DESCRIPTION
This is what I came up with for viewing local html/xml files without Sight interfering. I see that html and xml are already filtered by `contentType`. When viewing a local file `contentType` is `null`, and the `language` is `html` or `xml`. I added a check for that and now Sight will not highlight xml and html when `contentType` is `null`.