### PR TITLE
Fix error on options page (issue #61) 

### DIFF
--- a/js/options.js
+++ b/js/options.js
@@ -33,7 +33,7 @@
       fontSize: {
         selector: '#font-size',
         value: 'value',
-        decode: identity,
+        decode: id,
         render: function(value) {
           doc.getElementById('code').style.fontSize = value;
         },


### PR DESCRIPTION
Fix `ReferenceError: identity is not defined` error on options.html.