### PR TITLE
Add .cxx and .hxx as C++ file extensions

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -6,7 +6,7 @@
     brainfuck:   ['bf'],
     clojure:     ['clj'],
     coffeescript:['coffee'],
-    cpp:         ['c', 'h', 'cc', 'cpp', 'c++', 'hpp', 'h++'],
+    cpp:         ['c', 'h', 'cc', 'cpp', 'c++', 'hpp', 'hxx', 'h++'],
     cs:          ['cs'],
     css:         ['css'],
     d:           ['d', 'dd', 'di'],

--- a/js/background.js
+++ b/js/background.js
@@ -6,7 +6,7 @@
     brainfuck:   ['bf'],
     clojure:     ['clj'],
     coffeescript:['coffee'],
-    cpp:         ['c', 'h', 'cc', 'cpp', 'c++', 'hpp', 'hxx', 'h++'],
+    cpp:         ['c', 'h', 'cc', 'cpp', 'cxx', 'c++', 'hpp', 'hxx', 'h++'],
     cs:          ['cs'],
     css:         ['css'],
     d:           ['d', 'dd', 'di'],


### PR DESCRIPTION
.cxx is used by some (generally older) projects to store C++ source files.
.hxx is used to store C++ header files.