### PR TITLE
Implemented a "word wrap" option.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -74,10 +74,8 @@ body {
   -webkit-font-smoothing: subpixel-antialiased;
 }
 
-pre {
+.hljs {
   counter-reset: lines;
-  word-wrap: normal !important;
-  white-space: pre !important;
   font-family: inherit;
   line-height: normal;
   outline: none;
@@ -85,19 +83,31 @@ pre {
   display: block;
   overflow: visible;
 }
-
-pre .line {
-  counter-increment: lines;
-  -webkit-user-select: none;
+.hljs:not(.word-wrap) {
+  word-wrap: normal !important;
+  white-space: pre !important;
 }
 
-pre .line::before {
-  content: counter(lines);
-  text-align: right;
-  display: inline-block;
-  width: 2em;
-  padding-right: 0.5em;
-  margin-right: 0.5em;
-  color: #BBB;
+.hljs .line-number {
+  counter-increment: lines;
+  -webkit-user-select: none;
   border-right: solid 1px;
+  color: #BBB;
+  padding-right: 0.5em;
+  min-width: 2em;
+  text-align: right;
+}
+
+.hljs .line-number::before {
+  content: counter(lines);
+  display: inline-block;
+}
+
+.hljs .line-content {
+  padding-left: 0.5em;
+  word-wrap: normal;
+  white-space: pre;
+}
+.hljs.word-wrap .line-content {
+  white-space: pre-wrap;
 }

--- a/js/background.js
+++ b/js/background.js
@@ -77,7 +77,8 @@
     theme: 'sunburst',
     font: 'Inconsolata',
     fontSize: 'medium',
-    lineNumbers: true
+    lineNumbers: true,
+    wordWrap: false
   };
 
   const OPTIONS = Object.keys(OPTIONS_DEFAULTS);
@@ -135,14 +136,19 @@
                                                   EXT_LANG_MAP[filename];
   }
 
-  function getHighlightingCode(font, fontSize, lineNumbers, language) {
-    return 'document.body.style.fontFamily = "' + font + '";' +
-      'document.body.style.fontSize = "' + fontSize + '";' +
-      'var container = document.querySelector("pre");' +
-      'container.classList.add("' + language + '");' +
-      'hljs.configure({ lineNumbers: ' + lineNumbers + ' });' +
-      'hljs.highlightBlock(container);' +
-      'document.body.style.backgroundColor = getComputedStyle(container).backgroundColor;';
+  function getHighlightingCode(font, fontSize, lineNumbers, wordWrap, language) {
+    return 'document.body.style.fontFamily = "' + font + '";\n' +
+      'document.body.style.fontSize = "' + fontSize + '";\n' +
+      'var container = document.querySelector("pre");\n' +
+      'container.classList.add("' + language + '");\n' +
+      'if (' + wordWrap + ') container.classList.add("word-wrap");\n'+
+      'hljs.highlightBlock(container);\n' +
+      'var containerStyle = getComputedStyle(container);\n' +
+      'if (' + lineNumbers + ') container.innerHTML = "<table style=\'color:inherit\'>" + container.innerHTML' +
+      '.replace(/^(.*)$/gm, function(_, line) {\n' +
+      '  return \'<tr><td class="line-number"></td><td class="line-content">\' + line + \'</td></tr>\';\n' +
+      '}) + "</table>";\n' +
+      'document.body.style.backgroundColor = containerStyle.backgroundColor;';
   }
 
   const JS_BEUTIFY_CODE =
@@ -179,7 +185,7 @@
     }
 
     scripts.push({
-      code: getHighlightingCode.apply(this, ['font', 'fontSize', 'lineNumbers'].
+      code: getHighlightingCode.apply(this, ['font', 'fontSize', 'lineNumbers', 'wordWrap'].
         map(localStorage.getItem.bind(localStorage)).concat(language))
     });
 

--- a/js/options.js
+++ b/js/options.js
@@ -39,9 +39,25 @@
       decode: eq('true'),
       render: function(value) {
         var codeEl = doc.getElementById('code');
-        hljs.configure({ lineNumbers: value });
         codeEl.innerHTML = codeEl.textContent;
         hljs.highlightBlock(codeEl);
+        if (value) {
+          codeEl.innerHTML = '<table style="color:inherit">' +
+          codeEl.innerHTML.replace(/^(.*)$/gm, function(_, line) {
+            return '<tr><td class="line-number"></td><td class="line-content">' + line + '</td></tr>';
+          }) + "</table>";
+        }
+      }
+    },
+    wordWrap: {
+      selector: '#word-wrap',
+      value: 'checked',
+      decode: eq('true'),
+      render: function(value) {
+        var codeEl = doc.getElementById('code');
+        if (value) {
+          codeEl.classList.add("word-wrap");
+        } else codeEl.classList.remove("word-wrap");
       }
     }
   };

--- a/options.html
+++ b/options.html
@@ -92,6 +92,7 @@
         <option value="xx-large">xx-large</option>
       </select>
       <h3>Line numbers:<input id="line-numbers" type="checkbox"></h3>
+      <h3>Word wrap:<input id="word-wrap" type="checkbox"></h3>
       <pre id="code" class="go">
 package main
 


### PR DESCRIPTION
There are likely cleaner possible solutions (move now-shared table creation code to a separate JS file?), but this does work correctly.