### PR TITLE
resolve #91 yml

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -68,7 +68,7 @@
     vbscript:    ['vbs'],
     vhdl:        ['vhd', 'vhdl'],
     xml:         ['atom', 'rss', 'vsproj', 'csproj', 'build', 'wsdl', 'config', 'xsd', 'plist', 'xib'],
-    yaml:        ['yaml']
+    yaml:        ['yaml', 'yml']
   };
 
   const BROWSER_CONTENT = ['htm', 'html', 'xml', 'xhtml', 'shtml'];


### PR DESCRIPTION
- added `yml` to `yaml` language extensions

references:
* [YAML](https://en.wikipedia.org/wiki/YAML)

Signed-off-by: Max Kovgan <maxk@devopsent.biz>