### PR TITLE
'hh' is used for C++ Headers

### DIFF
--- a/js/languages/cpp.js
+++ b/js/languages/cpp.js
@@ -35,7 +35,7 @@ hljs.registerLanguage('cpp', function(hljs) {
       'vfprintf vprintf vsprintf'
   };
   return {
-    aliases: ['c', 'cc', 'h', 'c++', 'h++', 'hpp'],
+    aliases: ['c', 'cc', 'h', 'hh', 'c++', 'h++', 'hpp'],
     keywords: CPP_KEYWORDS,
     illegal: '</',
     contains: [


### PR DESCRIPTION
Adds hh as a valid alias for C++ header files.