### PR TITLE
Parse the filename correctly

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -114,7 +114,7 @@
   }
 
   function getFilenameFromUrl(url) {
-    return url.split('/').pop().split('?').shift().toLowerCase();
+    return url.split('?').shift().split('/').pop().toLowerCase();
   }
 
   function getExtensionFromFilename(filename) {


### PR DESCRIPTION
Remove the URL query parameters before extracting the filename from the URL.

If the URL query parameters contain slashes, when the function split the URL string, it got the filename wrongly. Therefore, the syntax highligthing does not work properly.

For example:
```
https://gerrit.example.com/path/to/file.c?h=branch/name
```
was returning _"name"_ as filename, when the expected output was _"file.c"_.

Signed-off-by: Javier Albornoz <javier.albornoz@hpe.com>