### PR TITLE
Option of user-specified font

### DIFF
--- a/options.html
+++ b/options.html
@@ -69,7 +69,8 @@
         <option value="zenburn">zenburn</option>
       </select>
       <h3>Select your font</h3>
-      <select id="font">
+      <input id="font" list="fonts-list">
+      <datalist id="fonts-list">
         <option value="Inconsolata">Inconsolata</option>
         <option value="Courier New">Courier New</option>
         <option value="Monaco">Monaco</option>
@@ -80,7 +81,7 @@
         <option value="ProFont">ProFont</option>
         <option value="ProggyClean">Proggy Clean</option>
         <option value="Consolas">Consolas</option>
-      </select>
+      </datalist>
       <h3>Select your font size</h3>
       <select id="font-size">
         <option value="xx-small">xx-small</option>


### PR DESCRIPTION
Previously, users were limited to picking from a fixed list of font options.

This change allows the user to type in the name of any locally installed font. There is also an unobtrusive autocomplete dropdown to let them easily choose one of the fonts that ships with Sight.