### PR TITLE
Highlight `log` files as bash

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -6,7 +6,7 @@
     applescript: ['applescript'],
     aspectj:     ['aspectj', 'aj'],
     avrasm:      ['asm', 's'],
-    bash:        ['sh', 'bash', 'zsh', 'shell'],
+    bash:        ['sh', 'bash', 'zsh', 'shell', 'log'],
     brainfuck:   ['bf'],
     clojure:     ['clj'],
     coffeescript:['coffee'],


### PR DESCRIPTION
I think log files are typically intended to be output in a shell, so setting them to be highlighted with the `bash` syntax.